### PR TITLE
[Refactor] Add Company Website to Integration Configuration Settings & Update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,13 @@
-# Telex Blogger Agent V1.0
+# Telex Blogger Agent V1.1
 
 ## Overview
 The **Telex Blogger** Agent is an AI-driven assistant that leverages the **Gemini API** to generate high-quality blog posts. Designed for seamless integration with Telex, it enables users to automate their **blog content** creation effortlessly.
+
+## What's New in V1.1
+✅ **Personalized Content Generation**: Users can now apply **custom personalization settings** to enhance blog content.
+✅ **Company Website for CTA**: The AI now automatically includes a **call-to-action (CTA)** linking to the user’s company website in the blog post conclusion.
+✅ **Enhanced API Flexibility**: The agent dynamically retrieves settings based on labels, making it more reusable and adaptable.
+✅ **Refactored Codebase**: Improved structure for better scalability and maintainability.
 
 ## 1. Setting Up the Blogger Agent in Telex
 To begin using the **Blogger Agent** in Telex, follow these steps:
@@ -16,7 +22,7 @@ To begin using the **Blogger Agent** in Telex, follow these steps:
    https://telex-blogger-agent-qdp4.onrender.com/api/v1/telex-integration
    ```
 4. Locate **Telex Blogger Agent** in the integration list and **Activate** it.
-5. **Enter your channel’s webhook URL** in the settings field to allow the agent to send generated blog posts to your desired channel.
+5. **Enter your channel’s webhook URL** and **input the personalization options** provided in the settings field. These options help tailor the AI-generated blog posts according to your preferences.
 6. Click **Save** to complete the setup.
 
 ### Step 2: Generating Blog Content in Telex
@@ -30,7 +36,7 @@ You can generate a blog post by sending a message in Telex with an optional cont
 "Generate a blog post on The Future of AI in Blogging"
 ```
 
-The agent will **automatically send a structured blog post** to the webhook URL you provided during integration setup in the format of title, introduction, body and conclusion.
+The agent will **automatically send a structured blog post** to the webhook URL you provided during integration setup in the format of title, introduction, body, and conclusion.
 
 ## 2. API Endpoints For Testing
 The Blogger Agent provides two API endpoints:
@@ -38,7 +44,7 @@ The Blogger Agent provides two API endpoints:
 ---
 
 ### 1️⃣ Generate Blog Post (POST)
-Generates a blog post based on user input.
+Generates a blog post based on user input with **personalization settings**.
 
 👉 **Endpoint URL:**
 ```
@@ -46,9 +52,6 @@ POST https://telex-blogger-agent-qdp4.onrender.com/api/v1/blogger-agent/generate
 ```
 
 👉 **Request Body (JSON):**
-
-Make sure to provide your channel webhook URL in the default payload. If not, the blog post will not be sent to the telex channel.
-
 ```json
 {
   "message": "Generate a blog post on The Impact of AI on Content Writing",
@@ -58,20 +61,25 @@ Make sure to provide your channel webhook URL in the default payload. If not, th
       "type": "text",
       "required": true,
       "default": "https://your-webhook-url"
+    },
+    {
+      "label": "company_website",
+      "type": "text",
+      "required": false,
+      "default": "https://your-company-website.com"
     }
   ]
 }
 ```
 
 👉 **Response:**
-
 The response is a plain string containing the message you sent. The blog request is processed in the background.
 
 ```
 Generate a blog post on The Impact of AI on Content Writing
 ```
 
-Once the blog is generated, it will be **automatically sent** to the channel with the webhook URL you provided. This is done within a few seconds.
+Once the blog is generated, it will be **automatically sent** to the channel with the webhook URL you provided. The AI will also **append a call-to-action** at the end linking to your company website (if provided).
 
 ---
 
@@ -84,13 +92,11 @@ GET https://telex-blogger-agent-qdp4.onrender.com/api/v1/telex-integration
 ```
 
 👉 **Response:**
-
-Retrieves the integration.json configuration for the agent. Example:
+Retrieves the integration.json configuration for the agent.
 
 ```
 {"data":{"date":{"created_at":"2025-03-10","updated_at":"2025-03-10"},"descriptions":{"app_description":"AI-powered Blogging Assistant for Telex"},"integration_category":"AI & Machine Learning","integration_type":"modifier"}}
 ```
-
 
 ## 3. Project Structure
 ```
@@ -98,7 +104,7 @@ Retrieves the integration.json configuration for the agent. Example:
 │── TelexBloggerAgent/                 
 │   ├── Controllers/                    
 │   │   ├── BloggerAgentController.cs   
-│   │   ├── TelexIntegrationController.cs 
+│   │   ├── TelexIntegrationController.cs
 │   │   │
 │   ├── Dtos/
 │   │   ├── GenerateBlogDto.cs         
@@ -110,16 +116,16 @@ Retrieves the integration.json configuration for the agent. Example:
 │   │   │
 │   ├── IServices/
 │   │   ├── IBlogAgentService.cs        
-│   │   ├── ITelexIntegrationService.cs 
+│   │   ├── ITelexIntegrationService.cs
 │   │   │
 │   ├── Services/                        
 │   │   ├── BlogAgentService.cs        
 │   │   ├── TelexIntegrationService.cs  
 │   │   │
-|   ├── appsettings.json
+│   ├── appsettings.json
 │   ├── Integration.json                
 │   ├── Program.cs                     
-│                              
+│                               
 │── README.md                           
 │── .gitignore                          
 │── Dockerfile                          
@@ -188,13 +194,5 @@ Ensure the output contains the generated blog content.
 3️⃣ **Verify in Telex**
 Check your Telex channel to see if the generated blog post was sent to the **channel webhook URL** you provided.
 
-## Conclusion
-The **Telex Blogger Agent** simplifies blog writing by leveraging **AI-powered content generation**. With seamless integration into **Telex**, users can generate high-quality blog posts effortlessly.
-
-🚀 **Start using it today and automate your blogging process!** 🚀
-
-### Main Updates in This Version:
-✅ **Webhook URL setting**: Users must provide a webhook URL to receive generated blog posts.  
-✅ **Simplified commands**: No extra settings required in Telex commands.  
-✅ **Automated posting**: Blog posts are sent directly to the configured Telex webhook.
+🚀 **Upgrade to V1.1 and take your blog automation to the next level!** 🚀
 

--- a/TelexBloggerAgent/Integration.json
+++ b/TelexBloggerAgent/Integration.json
@@ -49,6 +49,13 @@
         "required": false
       },
       {
+        "label": "company_website",
+        "type": "text",
+        "description": "Provide the company’s website URL to be included in the blog post conclusion.",
+        "default": "https://www.technology-innovators.com",
+        "required": false
+      },
+      {
         "label": "tone",
         "type": "dropdown",
         "description": "Choose the tone for the blog content.",

--- a/TelexBloggerAgent/Services/BlogAgentService.cs
+++ b/TelexBloggerAgent/Services/BlogAgentService.cs
@@ -89,17 +89,6 @@ namespace TelexBloggerAgent.Services
         }
 
 
-
-        //private string FormatBlogPrompt(string userPrompt)
-        //{
-        //    return $"{userPrompt}. Ensure the response is a well-structured, engaging, and informative article. " +
-        //           "Start with an attention-grabbing opening, provide valuable insights in a natural flow, and end with a compelling conclusion." +
-        //           "Keep the content clear with a title, introduction, body and conclusion, which should not be explicitly categorized." +
-        //           "Return it as plain text without markdown formatting." +
-        //           "Use ALL CAPS for section headers and to emphasize important words, and use (•) for bullet points";
-        //}
-
-
         public async Task GenerateBlogAsync(GenerateBlogDto blogPrompt)
         {
             if (blogPrompt.Message.Contains(identifier))


### PR DESCRIPTION
Description
This PR introduces a new company website field in the Telex Blogger Agent configuration, allowing users to add their business URL to the generated blog posts as a call-to-action (CTA). Additionally, the README has been updated to reflect this change.

Key Changes:
✅ Added company_website field in TelexSettings.cs and Integration.json
✅ Updated API Documentation in README.md