### PR TITLE
Feat: Implemented a Temporary Conversation list for different channels using the channel id

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,13 +57,8 @@ POST https://telex-blogger-agent-qdp4.onrender.com/api/v1/blogger-agent/generate
 ```json
 {
   "message": "Generate a blog post on The Impact of AI on Content Writing",
+  "channel_id": "0195bebf-a5e2-7b26-8eb5-a585a61d8188"
   "settings": [
-    {
-      "label": "webhook_url",
-      "type": "text",
-      "required": true,
-      "default": "https://your-webhook-url"
-    },
     {
       "label": "company_name",
       "type": "text",

--- a/TelexBloggerAgent.test/Services/BloggerAgentServiceTests.cs
+++ b/TelexBloggerAgent.test/Services/BloggerAgentServiceTests.cs
@@ -108,7 +108,7 @@ namespace TelexBloggerAgent.test.Services
         {
             var settings = new List<Setting> { new Setting { Label = "some_other_setting", Default = "value" } };
 
-            await Assert.ThrowsAsync<Exception>(() => _blogAgentService.SendBlogAsync("Generated Blog", settings));
+            await Assert.ThrowsAsync<Exception>(() => _blogAgentService.SendResponseAsync("Generated Blog", settings));
         }
 
 
@@ -121,7 +121,7 @@ namespace TelexBloggerAgent.test.Services
                 .Setup<Task<HttpResponseMessage>>("SendAsync", ItExpr.IsAny<HttpRequestMessage>(), ItExpr.IsAny<CancellationToken>())
                 .ReturnsAsync(new HttpResponseMessage { StatusCode = HttpStatusCode.Accepted });
 
-            await _blogAgentService.SendBlogAsync("Generated Blog", settings);
+            await _blogAgentService.SendResponseAsync("Generated Blog", settings);
 
             _loggerMock.Verify(logger =>
                 logger.Log(

--- a/TelexBloggerAgent/Controllers/BloggerAgentController.cs
+++ b/TelexBloggerAgent/Controllers/BloggerAgentController.cs
@@ -24,17 +24,21 @@ namespace TelexBloggerAgent.Controllers
         [ProducesResponseType(typeof(GenerateBlogDto), StatusCodes.Status200OK)]
         public async Task<IActionResult> ProcessBlog([FromBody] GenerateBlogDto blogDto)
         {
-            if (string.IsNullOrEmpty(blogDto.Message) || blogDto.Settings == null)
+            if (string.IsNullOrEmpty(blogDto.Message))
             {
-                return BadRequest("Message or Settings cannot be null");
+                return BadRequest("Message is required");
+            }
+            if (string.IsNullOrEmpty(blogDto.ChannelId))
+            {
+                return BadRequest("Channel Id is required");
             }
 
-            _logger.LogInformation($"{blogDto}");
-            //var response = await _blogService.HandleAsync(blogDto);
+            _logger.LogInformation($"Request received: {blogDto}");
+
             Task.Run(() => _blogService.HandleAsync(blogDto));
 
             //return Ok(blogDto.Message);
-            return Ok();
+            return Ok(blogDto.Message);
         }
       
     }

--- a/TelexBloggerAgent/Dtos/GenerateBlogDto.cs
+++ b/TelexBloggerAgent/Dtos/GenerateBlogDto.cs
@@ -1,7 +1,11 @@
-﻿namespace TelexBloggerAgent.Dtos
+﻿using System.Text.Json.Serialization;
+
+namespace TelexBloggerAgent.Dtos
 {
     public class GenerateBlogDto
-    {        
+    {
+        [JsonPropertyName("channel_id")]
+        public string ChannelId { get; set; }
         public string Message { get; set; }
         public List<Setting> Settings { get; set; }
     }

--- a/TelexBloggerAgent/IServices/IBlogAgentService.cs
+++ b/TelexBloggerAgent/IServices/IBlogAgentService.cs
@@ -4,8 +4,8 @@ namespace TelexBloggerAgent.IServices
 {
     public interface IBlogAgentService
     {
-        Task<string> GenerateResponse(string message, string systemMessage);
+        Task<string> GenerateResponse(string message, string systemMessage, string channelId);
         Task<string> HandleAsync(GenerateBlogDto blogPrompt);
-        Task<bool> SendBlogAsync(string blogPost, List<Setting> settings);
+        Task<bool> SendResponseAsync(string blogPost, List<Setting> settings, string channelId);
     }
 }

--- a/TelexBloggerAgent/Integration.json
+++ b/TelexBloggerAgent/Integration.json
@@ -28,13 +28,6 @@
     },
     "settings": [
       {
-        "label": "webhook_url",
-        "type": "text",
-        "description": "Provide your telex channel webhook url.",
-        "default": "",
-        "required": true
-      },
-      {
         "label": "company_name",
         "type": "text",
         "description": "Provide the name of the company/brand that the blog content should align with",

--- a/TelexBloggerAgent/Services/BlogAgentService.cs
+++ b/TelexBloggerAgent/Services/BlogAgentService.cs
@@ -5,26 +5,30 @@ using TelexBloggerAgent.Helpers;
 using TelexBloggerAgent.IServices;
 using TelexBloggerAgent.Dtos;
 using TelexBloggerAgent.Dtos.GeminiDto;
+using System.Threading.Channels;
 
 namespace TelexBloggerAgent.Services
 {
     public class BlogAgentService : IBlogAgentService
     {
-        private static readonly List<ChatMessage> conversations = new();
+        private static readonly Dictionary<string, List<ChatMessage>> conversations = new(); // Group messages by channelId
+        private static readonly List<ChatMessage> tconversations = new();
 
         const string identifier = "📝 #TelexBlog"; // Identifier
         private readonly HttpClient _httpClient;
         private ILogger<BlogAgentService> _logger;
+        private string _webhookUrl;
         private readonly string _apiKey;
         private readonly string _geminiUrl;
         private readonly IRequestProcessingService _requestService;
 
 
-        public BlogAgentService(IHttpClientFactory httpClientFactory, IOptions<GeminiSetting> geminiSettings, ILogger<BlogAgentService> logger, IRequestProcessingService requestService)
+        public BlogAgentService(IHttpClientFactory httpClientFactory, IOptions<GeminiSetting> geminiSettings, IOptions<TelexSetting> telexSettings, ILogger<BlogAgentService> logger, IRequestProcessingService requestService)
         {
             _httpClient = httpClientFactory.CreateClient();
             _apiKey = geminiSettings.Value.ApiKey;
             _geminiUrl = geminiSettings.Value.GeminiUrl;
+            _webhookUrl = telexSettings.Value.WebhookUrl;
             _requestService = requestService;
             _logger = logger;
         }
@@ -47,7 +51,7 @@ namespace TelexBloggerAgent.Services
                 var request = await _requestService.ProcessUserInputAsync(blogPrompt);
                 
                 // Generate the blog post using the formatted message
-                var aiResponse = await GenerateResponse(request.UserPrompt, request.SystemMessage);
+                var aiResponse = await GenerateResponse(request.UserPrompt, request.SystemMessage, blogPrompt.ChannelId);
 
                 // Throw an exception if the blog post generation failed
                 if (string.IsNullOrEmpty(aiResponse))
@@ -59,7 +63,7 @@ namespace TelexBloggerAgent.Services
                 var signedResponse = $"{aiResponse}\n\n{identifier}";
 
                 // Send the generated blog post to Telex
-                var suceeded = await SendBlogAsync(signedResponse, blogPrompt.Settings);
+                var suceeded = await SendResponseAsync(signedResponse, blogPrompt.Settings, blogPrompt.ChannelId);
 
                 // Throw an exception if sending the blog post failed
                 if (!suceeded)
@@ -77,8 +81,13 @@ namespace TelexBloggerAgent.Services
             }
         }
 
-        public async Task<string> GenerateResponse(string message, string systemMessage)
+        public async Task<string> GenerateResponse(string message, string systemMessage, string channelId)
         {
+            // Ensure channelId exists in the dictionary
+            if (!conversations.ContainsKey(channelId))
+            {
+                conversations[channelId] = new List<ChatMessage>();
+            }
 
             var userMessage = new ChatMessage
             {
@@ -86,35 +95,32 @@ namespace TelexBloggerAgent.Services
                 Parts = { new Part { Text = message } }
             };
 
-            conversations.Add(userMessage);
+            conversations[channelId].Add(userMessage);
 
-            // Create the request body for the Gemini API call
+            // Prepare the AI request body
             var requestBody = new GeminiRequest
             {
                 SystemInstruction = new SystemMessage
                 {
-                    Parts = { Text = systemMessage } 
+                    Parts = { Text = systemMessage }
                 },
-                Contents = conversations
-               
+                Contents = conversations[channelId] // Send only messages for this channel
             };
-            // Serialize the request body to JSON
+
             var content = new StringContent(JsonSerializer.Serialize(requestBody), Encoding.UTF8, "application/json");
+            _logger.LogInformation("Sending message to AI for channel {channelId}...", channelId);
 
-            _logger.LogInformation("Generating blog post.....");
-
-            // Send the request to the Gemini API
             var response = await _httpClient.PostAsync($"{_geminiUrl}?key={_apiKey}", content);
 
             if (!response.IsSuccessStatusCode)
             {
-                _logger.LogError("An error occured while sending the message to the AI");
-                throw new Exception($"An error occured : {response}");
+                _logger.LogError("Failed to send message to AI for channel {channelId}.", channelId);
+                throw new Exception("Error communicating with AI");
             }
-
-           
-
+        
+                       
             var responseString = await response.Content.ReadAsStringAsync();
+
             // Deserialize the response from the Gemini API
             var responseJson = JsonSerializer.Deserialize<JsonElement>(responseString);
 
@@ -138,7 +144,7 @@ namespace TelexBloggerAgent.Services
                 throw new Exception("Failed to generate response");
             }
 
-            _logger.LogInformation("Response generated successfully");
+            _logger.LogInformation("Message successfully generated by the AI for channel {channelId}.", channelId);
 
             // Add the generated response to the request body contents
             var modelResponse = new ChatMessage()
@@ -147,13 +153,13 @@ namespace TelexBloggerAgent.Services
                 Parts = { new Part { Text = generatedResponse } }
             };
 
-            conversations.Add(modelResponse);
+            conversations[channelId].Add(modelResponse);
 
             // Return the generated response
             return generatedResponse;
         }
 
-        public async Task<bool> SendBlogAsync(string blogPost, List<Setting> settings)
+        public async Task<bool> SendResponseAsync(string blogPost, List<Setting> settings, string channelId)
         {
 
             // Define the payload for the telex channel
@@ -170,28 +176,19 @@ namespace TelexBloggerAgent.Services
             var jsonPayload = JsonSerializer.Serialize(payload);
             using var telexContent = new StringContent(jsonPayload, new UTF8Encoding(false), "application/json");
 
-            var telexWebhookUrl = settings
-                .FirstOrDefault(s => s.Label == "webhook_url")?.Default
-                .ToString();
-
-            // Throw an error if telex webhook url is empty
-            if (string.IsNullOrEmpty(telexWebhookUrl))
-            {
-                throw new Exception("Telex Webhook Url is null");
-            }
-
+            
             // Send the response to telex
-            var telexResponse = await _httpClient.PostAsync(telexWebhookUrl, telexContent);
+            var telexResponse = await _httpClient.PostAsync($"{_webhookUrl}/{channelId}", telexContent);
 
-            if ((int)telexResponse.StatusCode == StatusCodes.Status202Accepted)
+            if ((int)telexResponse.StatusCode != StatusCodes.Status202Accepted)
             {
-                string responseContent = await telexResponse.Content.ReadAsStringAsync();
-                _logger.LogInformation("Blog post successfully sent to telex");
-
-                return true;
+                _logger.LogInformation("Failed to send response to telex");
+                return false;
             }
+                string responseContent = await telexResponse.Content.ReadAsStringAsync();
+                _logger.LogInformation("Response successfully sent to telex");
 
-            return false;
+            return true;
         }
     }
 }

--- a/TelexBloggerAgent/Services/RequestProcessingService.cs
+++ b/TelexBloggerAgent/Services/RequestProcessingService.cs
@@ -11,7 +11,7 @@ namespace TelexBloggerAgent.Services
         { "create", "generate", "write", "blog", "article", "post", "compose" };
 
         private static readonly HashSet<string> TopicKeywords = new()
-        { "suggest", "give", "need", "blog", "topic", "idea", "recommend" };
+        { "suggest", "give", "need", "blog", "topic", "topics", "idea", "recommend" };
 
         private readonly CompanyService _companyService;
 
@@ -88,8 +88,8 @@ namespace TelexBloggerAgent.Services
             // Adjust content length
             prompt += blogLength switch
             {
-                "short" => " Keep the article concise, around 300 words, focusing on key points.",
-                "medium" => " Provide a balanced article, around 600 words, with in-depth insights.",
+                "short" => " Keep the article concise, around 400 words, focusing on key points.",
+                "medium" => " Provide a balanced article, around 800 words, with in-depth insights.",
                 "long" => " Create a comprehensive article, around 1000+ words, with detailed analysis.",
                 _ => ""
             };
@@ -122,7 +122,8 @@ namespace TelexBloggerAgent.Services
                 "If the user asks for you to generate or write or blog post, ensure the response is a well-structured, engaging, and informative article." +
                 "The responses should align with company's brand" +
                 "Only Introduce yourself when getting acquainted with the user for the first time" +
-                "Use ALL CAPS for important words, and use ✅ for bullet points.";
+                "Use ALL CAPS for important words, and use ✅ for bullet points." +
+                "Return response without markdown formatting";
           
 
             return systemMessage;
@@ -139,11 +140,8 @@ namespace TelexBloggerAgent.Services
             int blogScore = words.Count(word => BlogKeywords.Contains(word));
             int topicScore = words.Count(word => TopicKeywords.Contains(word));
 
-            if (blogScore > topicScore)
+            if (blogScore > topicScore && blogScore > 2)
                 return RequestType.BlogRequest;
-
-            if (topicScore > blogScore)
-                return RequestType.TopicRequest;
 
             return RequestType.Uncertain;
         }


### PR DESCRIPTION
Key Changes:
- Add a temporary list to store the chat sessions per channel using the channel id.
- Modify the readme to reflect the correct settings for the integration.
- Modify the controller to validate and ensure that channel id is not empty.